### PR TITLE
Add skeleton for cli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
     rev: v1.9.0
     hooks:
       - id: mypy
+        additional_dependencies: [types-toml==0.10.8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "gotranx",
     "fenics-beat",
     "fenics-pulse",
+    "toml"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["cardiac", "electro-mechanics"]
 dependencies = [
-    "numpy",
+    "numpy<2.0",
     "gotranx",
     "fenics-beat",
     "fenics-pulse",

--- a/src/simcardems2/__main__.py
+++ b/src/simcardems2/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/simcardems2/cli.py
+++ b/src/simcardems2/cli.py
@@ -1,0 +1,27 @@
+from typing import Sequence
+import argparse
+from pathlib import Path
+import toml
+import dolfin
+
+
+def run(mesh_path: Path, output_path: Path):
+    output_path = Path(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+    mesh = dolfin.Mesh()
+    with dolfin.XDMFFile(str(mesh_path)) as f:
+        f.read(mesh)
+
+    msg = f"Mesh has {mesh.num_vertices()} vertices."
+    print(msg)
+    (output_path / "output.txt").write_text(msg)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Simcardems CLI")
+    parser.add_argument("config-file", type=Path, help="Config file")
+
+    args = vars(parser.parse_args(argv))
+    config_file = toml.loads(args["config-file"].read_text())
+    run(**config_file)
+    return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,3 +12,4 @@ def test_cli(tmp_path):
 
     config_path.write_text(toml.dumps(config))
     assert main([str(config_path)]) == 0
+    assert (tmp_path / "results/output.txt").read_text() == "Mesh has 216 vertices."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,4 +12,5 @@ def test_cli(tmp_path):
 
     config_path.write_text(toml.dumps(config))
     assert main([str(config_path)]) == 0
+    assert (tmp_path / "results/output.txt").is_file()
     assert (tmp_path / "results/output.txt").read_text() == "Mesh has 216 vertices."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import dolfin
+import toml
+from simcardems2.cli import main
+
+
+def test_cli(tmp_path):
+    mesh = dolfin.UnitCubeMesh(5, 5, 5)
+    with dolfin.XDMFFile(str(tmp_path / "mesh.xdmf")) as f:
+        f.write(mesh)
+    config = {"mesh_path": str(tmp_path / "mesh.xdmf"), "output_path": str(tmp_path / "results")}
+    config_path = tmp_path / "config.toml"
+
+    config_path.write_text(toml.dumps(config))
+    assert main([str(config_path)]) == 0


### PR DESCRIPTION
The `__main__.py` makes it possible to run the command as
```
python3 -m simcardems2
```
Add also a simple test which just loads the mesh and prints the number of vertices